### PR TITLE
feat: Add separate connect timeout with 60s default (CLIM-566)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,5 +15,6 @@
 - Utils: calendar_year_bounds, calendar_year_bounds_for, period_key, period_start_end, next_period_id.
 ### Changed
 - Default dependency: convertdate>=2.4 for multi-calendar support.
+- HTTP timeout controls: added `connect_timeout` (default 60s) while keeping `timeout` for read/write/pool (default 30s).
 ### Validation
 - Error if data element is linked to datasets with mixed periodType.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ cfg = ClientSettings(
     base_url="http://localhost:8080",
     username="admin",
     password="district",
+    connect_timeout=60.0,   # default connect timeout (cold-start friendly)
+    timeout=30.0,           # default read/write/pool timeout
     log_level="INFO",        # default "WARNING"
     log_format="json",       # default "json"; use "text" for human-readable
     log_destination="stdout" # default "stderr"; can also be file path
@@ -140,6 +142,7 @@ client = DHIS2Client(settings=cfg, log_level="DEBUG")  # DEBUG takes precedence
 
 - **Default**: JSON logs at WARNING level to stderr.
 - **Configurable**: via ClientSettings or constructor kwargs.
+- **Timeouts**: `connect_timeout=60s` by default, `timeout=30s` for request read/write/pool.
 
 ```python
 # JSON (default) logs at INFO to stdout

--- a/src/dhis2_client/client.py
+++ b/src/dhis2_client/client.py
@@ -40,6 +40,7 @@ class DHIS2Client:
         token: str | None = None,
         default_page_size: int = 50,
         timeout: float = 30.0,
+        connect_timeout: float = 60.0,
         retries: int = 3,
         verify_ssl: bool = True,
         settings: ClientSettings | None = None,
@@ -62,6 +63,9 @@ class DHIS2Client:
                 default_page_size if default_page_size != 50 else settings.default_page_size
             )
             timeout = timeout if timeout != 30.0 else settings.timeout
+            connect_timeout = (
+                connect_timeout if connect_timeout != 60.0 else settings.connect_timeout
+            )
             retries = retries if retries != 3 else settings.retries
             verify_ssl = verify_ssl if verify_ssl is not True else settings.verify_ssl
             self.model_mode = settings.model_mode
@@ -80,6 +84,7 @@ class DHIS2Client:
         self.base_url = base_url.rstrip("/")
         self.default_page_size = int(default_page_size)
         self.timeout = float(timeout)
+        self.connect_timeout = float(connect_timeout)
         self.retries = int(retries)
         self.verify_ssl = bool(verify_ssl)
 
@@ -117,9 +122,10 @@ class DHIS2Client:
         }
         if self._token_header:
             headers["Authorization"] = self._token_header
+        timeout = httpx.Timeout(timeout=self.timeout, connect=self.connect_timeout)
         return httpx.Client(
             headers=headers,
-            timeout=self.timeout,
+            timeout=timeout,
             verify=self.verify_ssl,
         )
 

--- a/src/dhis2_client/settings.py
+++ b/src/dhis2_client/settings.py
@@ -27,6 +27,7 @@ class ClientSettings:
     # --- HTTP behavior ---
     default_page_size: int = 50
     timeout: float = 30.0
+    connect_timeout: float = 60.0
     retries: int = 3
     verify_ssl: bool = True
 

--- a/tests/test_client_core.py
+++ b/tests/test_client_core.py
@@ -1,3 +1,36 @@
-def test_placeholder():
-    # Basic smoke placeholder to keep CI green initially
-    assert isinstance(1, int)
+import httpx
+
+from dhis2_client import DHIS2Client
+from dhis2_client.settings import ClientSettings
+
+
+def test_default_timeouts():
+    c = DHIS2Client("http://test")
+    assert isinstance(c._client, httpx.Client)
+    timeout = c._client.timeout
+
+    assert timeout.connect == 60.0
+    assert timeout.read == 30.0
+    assert timeout.write == 30.0
+    assert timeout.pool == 30.0
+
+
+def test_custom_connect_timeout_kwarg():
+    c = DHIS2Client("http://test", timeout=20.0, connect_timeout=75.0)
+    timeout = c._client.timeout
+
+    assert timeout.connect == 75.0
+    assert timeout.read == 20.0
+    assert timeout.write == 20.0
+    assert timeout.pool == 20.0
+
+
+def test_connect_timeout_from_settings():
+    settings = ClientSettings(base_url="http://test", timeout=25.0, connect_timeout=90.0)
+    c = DHIS2Client(settings=settings)
+    timeout = c._client.timeout
+
+    assert timeout.connect == 90.0
+    assert timeout.read == 25.0
+    assert timeout.write == 25.0
+    assert timeout.pool == 25.0


### PR DESCRIPTION
Increases IM cold-start resilience by introducing a dedicated connect_timeout (default 60s) while keeping request read/write/pool timeout at 30s. This avoids connection failures on sleeping IM instances without globally relaxing all HTTP timeouts. Includes unit tests and README/changelog updates.